### PR TITLE
Equivalence tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,12 @@
+using Random
+using Test
+using SparseGPs
+
+const GROUP = get(ENV, "GROUP", "All")
+const PKGDIR = dirname(dirname(pathof(SparseGPs)))
+
+@testset "SparseGPs" begin
+    include("svgp.jl")
+    println(" ")
+    @info "Ran svgp tests"
+end

--- a/test/svgp.jl
+++ b/test/svgp.jl
@@ -1,0 +1,4 @@
+@testset "svgp" begin
+    x = 4
+    @test x == 4
+end


### PR DESCRIPTION
Adds tests which check the equivalence of certain models.

For example, sparse models with inducing inputs == training inputs should recover the exact GP posterior.